### PR TITLE
Feature/show list component

### DIFF
--- a/src/components/organisms/Content.tsx
+++ b/src/components/organisms/Content.tsx
@@ -33,7 +33,10 @@ const Content: React.FC = () => {
       <p>You clicked {count} times</p>
       <p>
         <button onClick={handleIncrement}>+1</button>
-        <Link to={`${routePath.GALLERY}/1`}><img src={Slide[count]} alt="" key={Slide[count]}/></Link>
+        <Link to={{
+          pathname:`${routePath.GALLERY}/${count + 1}`,
+          state: { listNum: count }
+        }}><img src={Slide[count]} alt="" key={Slide[count]}/></Link>
         <button onClick={handleDecrement}>-1</button>
       </p>
     </section>

--- a/src/components/organisms/Gallerylist.tsx
+++ b/src/components/organisms/Gallerylist.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { Gallery } from '../../constants/Images';
 
 
-interface listNumProps{
+interface ListNumProps{
   listNum: number,
 }
 
-export const GalleryList: React.FC<listNumProps> = (props) => {
+export const GalleryList: React.FC<ListNumProps> = (props) => {
   return(
     <p className="gallerylist">
       {Gallery[props.listNum].map((url, index) => <img src={Gallery[props.listNum][index]} alt={Gallery[props.listNum][index]} key={Gallery[props.listNum][index]}/>)}

--- a/src/components/organisms/Gallerylist.tsx
+++ b/src/components/organisms/Gallerylist.tsx
@@ -9,7 +9,7 @@ interface ListNumProps{
 export const GalleryList: React.FC<ListNumProps> = (props) => {
   return(
     <p className="gallerylist">
-      {Gallery[props.listNum].map((url, index) => <img src={Gallery[props.listNum][index]} alt={Gallery[props.listNum][index]} key={Gallery[props.listNum][index]}/>)}
+      {Gallery[props.listNum].map((url) => <img src={url} alt={url} key={url}/>)}
     </p>
   )
 }

--- a/src/components/organisms/Gallerylist.tsx
+++ b/src/components/organisms/Gallerylist.tsx
@@ -9,7 +9,7 @@ interface ListNumProps{
 export const GalleryList: React.FC<ListNumProps> = (props) => {
   return(
     <p className="gallerylist">
-      {Gallery[props.listNum].map((url) => <img src={url} alt={url} key={url}/>)}
+      {Gallery[props.listNum].map((imgPath: string) => <img src={imgPath} alt={imgPath} key={imgPath}/>)}
     </p>
   )
 }

--- a/src/components/pages/List.tsx
+++ b/src/components/pages/List.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import {GalleryList} from '../organisms/Gallerylist';
 
+interface ListNum {
+  listNum: number
+}
+
+interface StateList {
+  state: ListNum
+}
+
 interface ListNumProps{
-  listNum: number,
-  location: any
+  location: StateList
 }
 
 const List: React.FC<ListNumProps> = (props) => {

--- a/src/components/pages/List.tsx
+++ b/src/components/pages/List.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import {GalleryList} from '../organisms/Gallerylist';
 
-interface listNumProps{
+interface ListNumProps{
   listNum: number,
 }
 
-const List: React.FC<listNumProps> = (props) => {
+const List: React.FC<ListNumProps> = (props) => {
   const {listNum} = props
   return(
     <div>

--- a/src/components/pages/List.tsx
+++ b/src/components/pages/List.tsx
@@ -1,19 +1,13 @@
 import React from 'react';
+import * as H from 'history'
+import {RouteComponentProps} from 'react-router-dom'
 import {GalleryList} from '../organisms/Gallerylist';
 
-interface ListNum {
-  listNum: number
+interface ListProps extends RouteComponentProps{
+  location: H.Location<{listNum: number}>
 }
 
-interface StateList {
-  state: ListNum
-}
-
-interface ListNumProps{
-  location: StateList
-}
-
-const List: React.FC<ListNumProps> = (props) => {
+const List = (props: ListProps) => {
   return(
     <div>
       <GalleryList listNum={props.location.state.listNum} />

--- a/src/components/pages/List.tsx
+++ b/src/components/pages/List.tsx
@@ -3,13 +3,13 @@ import {GalleryList} from '../organisms/Gallerylist';
 
 interface ListNumProps{
   listNum: number,
+  location: any
 }
 
 const List: React.FC<ListNumProps> = (props) => {
-  const {listNum} = props
   return(
     <div>
-      <GalleryList listNum={listNum} />
+      <GalleryList listNum={props.location.state.listNum} />
     </div>
   )
 }


### PR DESCRIPTION
# Overview
* Modified so that List component can be displayed normally from each conductor using history
* How to pass the state of each conductor to the List component
* Recognized the state set for each link using the history and location of the Browser router

# Technical changes
* Clicking the text link of the Header component and the image link of the Content component displays a list of linked images in the List component
* Set the state to the text link of the Header component and the image link of the Content component, pass it to the List component, and pass props from the List component to the Gallerylist component to display a list of images based on the props


# Changes to the UI
* ![FireShot Capture 007 - React App - localhost](https://user-images.githubusercontent.com/35872217/74397478-1c78f880-4e58-11ea-8a3f-c2b867b15db9.png)
* ![FireShot Capture 006 - React App - localhost](https://user-images.githubusercontent.com/35872217/74397499-2a2e7e00-4e58-11ea-9b7b-16d1b3d01c20.png)



## ToDo put on hold this time
* [ ] Redux state management



## Review priority
* [ ] Immediately review
* [x] Review as soon as possible
* [ ] Review when you have time


# Related URL
* https://www.tmp1024.com/articles/typescript-interface-nest

# Ticket URL
* https://app.asana.com/0/1160661462508681/1160877668749993/f
